### PR TITLE
Run Civilization on 'play' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Upload you completed turn:
 OS Support
 ----------
 
-civility has only been minimally tested on OS X.
+civility has only been minimally tested on OS X and Windows.
 
 Security
 --------

--- a/lib/civility.rb
+++ b/lib/civility.rb
@@ -28,6 +28,15 @@ class Civility < Thor
   }
   SAVE_DIRECTORY = "#{PLATFORM_DIRS[OS]}/Saves/hotseat/"
 
+  CIV_APPID = 8930
+  RUN_URI = "steam://run/#{CIV_APPID}"
+  RUN_CMDS = {
+    windows: 'start',
+    mac: 'open',
+    linux: nil
+  }
+  RUN_CMD = "#{RUN_CMDS[OS]} #{RUN_URI}"
+
   def initialize(*args)
     @config = load_config
     @gmr = Civility::GMR.new(auth_key, user_id) if auth_key
@@ -69,6 +78,7 @@ class Civility < Thor
     data = @gmr.download(game['GameId'])
     save_file(path, data)
     puts "Saved #{game['Name']} to #{path}"
+    run_civilization
     sync_games
   end
 
@@ -217,6 +227,10 @@ class Civility < Thor
 
   def config_file?
     File.exist?(config_path)
+  end
+
+  def run_civilization
+    `#{RUN_CMD}`
   end
 end
 

--- a/lib/civility.rb
+++ b/lib/civility.rb
@@ -17,7 +17,7 @@ class Civility < Thor
     when /darwin/
       :mac
     else
-      :linux
+      fail "Unknown Platform #{RUBY_PLATFORM}"
     end
   end.call
 

--- a/lib/civility.rb
+++ b/lib/civility.rb
@@ -6,10 +6,27 @@ require 'thor'
 
 class Civility < Thor
   VERSION = '5'
-  SAVE_DIRECTORY = "/Documents/Aspyr/Sid\ Meier\'s\ Civilization\ 5/Saves/hotseat/"
   FILE_PREFIX = 'civility'
   FILE_EXT = 'Civ5Save'
   CONFIG_FILE = '.civility.yml'
+  OS = lambda do
+    # From http://stackoverflow.com/a/171011/1621312
+    case RUBY_PLATFORM
+    when /cygwin|mswin|mingw|bccwin|wince|emx/
+      :windows
+    when /darwin/
+      :mac
+    else
+      :linux
+    end
+  end.call
+
+  PLATFORM_DIRS = {
+    windows: "/Documents/my games/Sid Meier's Civilization 5",
+    mac: "/Documents/Aspyr/Sid\ Meier\'s\ Civilization\ 5",
+    linux: nil
+  }
+  SAVE_DIRECTORY = "#{PLATFORM_DIRS[OS]}/Saves/hotseat/"
 
   def initialize(*args)
     @config = load_config

--- a/lib/civility.rb
+++ b/lib/civility.rb
@@ -187,9 +187,9 @@ class Civility < Thor
   end
 
   def save_file(path, data)
-    file = open(path, 'wb')
-    file.write(data)
-    file.close
+    open(path, 'wb') do |file|
+      file.write(data)
+    end
   end
 
   def load_config


### PR DESCRIPTION
Runs Civ 5 using the [Steam browser protocol](https://developer.valvesoftware.com/wiki/Steam_browser_protocol) after the save is downloaded using the `play` command.

Depends on #6 , and could probably be improved to skip splash screens / intro videos
